### PR TITLE
Test authorized key works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ python:
 before_install:
   - pip install --upgrade codecov
   - mv .env.travis .env
+  - ssh-keygen -q -t rsa -b 4096 -f ~/.ssh/id_rsa -N '' -C django_remote_submission
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install --upgrade -r requirements_test.txt

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -481,9 +481,6 @@ def test_submit_job_deploy_key(env, job_gen, interpreter_gen, wrapper_cls):
     import os.path
     import time
 
-    if wrapper_cls.__name__ == 'LocalWrapper':
-        pytest.skip()
-
     try:
         from shlex import quote as cmd_quote
     except ImportError:
@@ -514,8 +511,6 @@ def test_submit_job_deploy_key(env, job_gen, interpreter_gen, wrapper_cls):
     submit_job_to_server(remove_existing_key_job.pk, env.remote_password,
                          wrapper_cls=wrapper_cls)
 
-    time.sleep(5)
-
     add_key_job = job_gen(
         program='''\
         true
@@ -526,8 +521,6 @@ def test_submit_job_deploy_key(env, job_gen, interpreter_gen, wrapper_cls):
     submit_job_to_server(add_key_job.pk, env.remote_password,
                          wrapper_cls=wrapper_cls)
 
-    time.sleep(5)
-
     simple_job = job_gen(
         program='''\
         true
@@ -536,5 +529,3 @@ def test_submit_job_deploy_key(env, job_gen, interpreter_gen, wrapper_cls):
     )
 
     submit_job_to_server(simple_job.pk, None, wrapper_cls=wrapper_cls)
-
-    time.sleep(5)


### PR DESCRIPTION
This adds tests to ensure that the deployment of keys works correctly when connecting to a server. To allow these tests to run on Travis, we also need to generate an ssh key before running the tests.